### PR TITLE
Conflict when user added twice, delete user endpoint

### DIFF
--- a/genotype_api/api/endpoints/users.py
+++ b/genotype_api/api/endpoints/users.py
@@ -42,7 +42,7 @@ def delete_user(
     return JSONResponse(content="User deleted successfully", status_code=status.HTTP_200_OK)
 
 
-@router.put("/{user_id}/email", response_model=UserReadWithPlates)
+@router.put("/{user_id}/email", response_model=User)
 def change_user_email(
     user_id: int,
     email: EmailStr,

--- a/genotype_api/api/endpoints/users.py
+++ b/genotype_api/api/endpoints/users.py
@@ -1,8 +1,9 @@
 """Routes for users"""
 
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import EmailStr
 from starlette import status
 from starlette.responses import JSONResponse
 
@@ -25,6 +26,7 @@ def read_user(
     return get_user(session=session, user_id=user_id)
 
 
+
 @router.delete("/{user_id}")
 def delete_user(
     user_id: int,
@@ -39,6 +41,22 @@ def delete_user(
     session.commit()
     session.flush()
     return JSONResponse(content="User deleted successfully", status_code=status.HTTP_200_OK)
+
+@router.put("/{user_id}/email", response_model=UserReadWithPlates)
+def change_user_email(
+    user_id: int,
+    email: EmailStr,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_active_user),
+) -> User:
+    user: User = get_user(session=session, user_id=user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user.email = email
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return User
 
 
 @router.get("/", response_model=List[UserRead])

--- a/genotype_api/api/endpoints/users.py
+++ b/genotype_api/api/endpoints/users.py
@@ -26,7 +26,7 @@ def read_user(
 
 
 @router.delete("/{user_id}")
-def read_user(
+def delete_user(
     user_id: int,
     session: Session = Depends(get_session),
     current_user: User = Depends(get_active_user),

--- a/genotype_api/api/endpoints/users.py
+++ b/genotype_api/api/endpoints/users.py
@@ -26,7 +26,6 @@ def read_user(
     return get_user(session=session, user_id=user_id)
 
 
-
 @router.delete("/{user_id}")
 def delete_user(
     user_id: int,
@@ -41,6 +40,7 @@ def delete_user(
     session.commit()
     session.flush()
     return JSONResponse(content="User deleted successfully", status_code=status.HTTP_200_OK)
+
 
 @router.put("/{user_id}/email", response_model=UserReadWithPlates)
 def change_user_email(

--- a/genotype_api/api/endpoints/users.py
+++ b/genotype_api/api/endpoints/users.py
@@ -56,7 +56,7 @@ def change_user_email(
     session.add(user)
     session.commit()
     session.refresh(user)
-    return User
+    return user
 
 
 @router.get("/", response_model=List[UserRead])

--- a/genotype_api/models.py
+++ b/genotype_api/models.py
@@ -141,6 +141,7 @@ class User(UserBase, table=True):
     plates: Optional[List["Plate"]] = Relationship(back_populates="user")
 
 
+
 class UserRead(UserBase):
     id: int
 

--- a/genotype_api/models.py
+++ b/genotype_api/models.py
@@ -141,7 +141,6 @@ class User(UserBase, table=True):
     plates: Optional[List["Plate"]] = Relationship(back_populates="user")
 
 
-
 class UserRead(UserBase):
     id: int
 


### PR DESCRIPTION
### Added
* Delete user endpoint
* Change email endpoint to replace "Archive user cli"

### Fixed
- Return 409 when trying to add existing user

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


