### PR TITLE
feat(check sex) More lenient check_sex function

### DIFF
--- a/genotype_api/constants.py
+++ b/genotype_api/constants.py
@@ -9,7 +9,7 @@ class TYPES(str, Enum):
 
 
 class SEXES(str, Enum):
-    MAIL = "male"
+    MALE = "male"
     FEMALE = "female"
     UNKNOWN = "unknown"
 

--- a/genotype_api/models.py
+++ b/genotype_api/models.py
@@ -313,8 +313,9 @@ def check_sex(sample_sex, genotype_analysis, sequence_analysis):
     if not sample_sex or genotype_analysis.sex == SEXES.UNKNOWN:
         return "fail"
     sexes = {genotype_analysis.sex, sequence_analysis.sex, sample_sex}
-    return not {SEXES.MALE, SEXES.FEMALE}.issubset(sexes)
-
+    if {SEXES.MALE, SEXES.FEMALE}.issubset(sexes):
+        return "fail"
+    return "pass"
 
 class AnalysisReadWithSampleDeep(AnalysisRead):
     sample: Optional[SampleReadWithAnalysisDeep]

--- a/genotype_api/models.py
+++ b/genotype_api/models.py
@@ -312,8 +312,8 @@ def check_sex(sample_sex, genotype_analysis, sequence_analysis):
     """Check if any source disagrees on the sex"""
     if not sample_sex or genotype_analysis.sex == SEXES.UNKNOWN:
         return "fail"
-    sexes = [genotype_analysis.sex, sequence_analysis.sex, sample_sex]
-    return SEXES.MALE not in sexes or SEXES.FEMALE not in sexes
+    sexes = {genotype_analysis.sex, sequence_analysis.sex, sample_sex}
+    return not {SEXES.MALE, SEXES.FEMALE}.issubset(sexes)
 
 
 class AnalysisReadWithSampleDeep(AnalysisRead):

--- a/genotype_api/models.py
+++ b/genotype_api/models.py
@@ -309,11 +309,11 @@ def check_snps(genotype_analysis, sequence_analysis):
 
 
 def check_sex(sample_sex, genotype_analysis, sequence_analysis):
-    if sample_sex in ["unknown", None]:
+    """Check if any source disagrees on the sex"""
+    if not sample_sex or genotype_analysis.sex == SEXES.UNKNOWN:
         return "fail"
-    elif genotype_analysis.sex == sequence_analysis.sex == sample_sex:
-        return "pass"
-    return "fail"
+    sexes = [genotype_analysis.sex, sequence_analysis.sex, sample_sex]
+    return SEXES.MALE not in sexes or SEXES.FEMALE not in sexes
 
 
 class AnalysisReadWithSampleDeep(AnalysisRead):

--- a/genotype_api/models.py
+++ b/genotype_api/models.py
@@ -317,6 +317,7 @@ def check_sex(sample_sex, genotype_analysis, sequence_analysis):
         return "fail"
     return "pass"
 
+
 class AnalysisReadWithSampleDeep(AnalysisRead):
     sample: Optional[SampleReadWithAnalysisDeep]
 


### PR DESCRIPTION
### Description

The balsamic pipeline will not perform a sex check. Thus `sequence_analysis.sex` will always be "unknown". This PR changes the check_sex function so that it only fails if:

1. Genotype fails to determine the sex.
2. sample sex (from database) i not provided at all (not even "unknown")
3. There is actual disagreement regarding the sex among the three sources (ie. both Male and Female occur)

### Changed
- check_sex is now more lenient with the "unknown" value.


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


