### PR TITLE
Fix(samples endpoint) Moved join(Analysis) out of smaller functions

### DIFF
--- a/genotype_api/api/endpoints/samples.py
+++ b/genotype_api/api/endpoints/samples.py
@@ -130,7 +130,7 @@ def update_sex(
     session: Session = Depends(get_session),
     current_user: User = Depends(get_active_user),
 ):
-    """Updating sex field on sample and sample analyses"""
+    """Updating sex field on sample and sample analyses."""
 
     sample_in_db: Sample = get_sample(session=session, sample_id=sample_id)
     sample_in_db.sex = sex
@@ -154,7 +154,7 @@ def update_comment(
     session: Session = Depends(get_session),
     current_user: User = Depends(get_active_user),
 ):
-    """Updating comment field on sample"""
+    """Updating comment field on sample."""
 
     sample_in_db: Sample = get_sample(session=session, sample_id=sample_id)
     sample_in_db.comment = comment
@@ -191,7 +191,7 @@ def match(
     session: Session = Depends(get_session),
     current_user: User = Depends(get_active_user),
 ) -> List[MatchResult]:
-    """Match sample genotype against all other genotypes"""
+    """Match sample genotype against all other genotypes."""
 
     all_genotypes: Analysis = session.query(Analysis).filter(
         Analysis.type == comparison_set,
@@ -243,7 +243,7 @@ def delete_sample(
     session: Session = Depends(get_session),
     current_user: User = Depends(get_active_user),
 ):
-    """Delete sample and its Analyses"""
+    """Delete sample and its Analyses."""
 
     sample: Sample = get_sample(session=session, sample_id=sample_id)
     for analysis in sample.analyses:

--- a/genotype_api/api/endpoints/samples.py
+++ b/genotype_api/api/endpoints/samples.py
@@ -96,7 +96,7 @@ def read_samples(
     current_user: User = Depends(get_active_user),
 ) -> List[Sample]:
     """Returns a list of samples matching the provided filters."""
-    statement: SelectOfScalar = select(Sample)
+    statement: SelectOfScalar = select(Sample).join(Analysis)
     if sample_id:
         statement: SelectOfScalar = get_samples(statement=statement, sample_id=sample_id)
     if plate_id:

--- a/genotype_api/crud/samples.py
+++ b/genotype_api/crud/samples.py
@@ -37,10 +37,8 @@ def create_sample(session: Session, sample: Sample) -> Sample:
 def get_incomplete_samples(statement: SelectOfScalar) -> SelectOfScalar:
     """Returning sample query statement for samples with less than two analyses."""
 
-    # return statement.join(Analysis).where(func.count(Sample.analyses) < 2)
     return (
-        statement.join(Analysis)
-        .group_by(Analysis.sample_id)
+        statement.group_by(Analysis.sample_id)
         .order_by(Analysis.created_at)
         .having(func.count(Analysis.sample_id) < 2)
     )
@@ -48,8 +46,7 @@ def get_incomplete_samples(statement: SelectOfScalar) -> SelectOfScalar:
 
 def get_plate_samples(statement: SelectOfScalar, plate_id: str) -> SelectOfScalar:
     """Returning sample query statement for samples analysed on a specific plate"""
-
-    return statement.join(Analysis).where(Analysis.plate_id == plate_id)
+    return statement.where(Analysis.plate_id == plate_id)
 
 
 def get_commented_samples(statement: SelectOfScalar) -> SelectOfScalar:

--- a/genotype_api/crud/samples.py
+++ b/genotype_api/crud/samples.py
@@ -11,7 +11,7 @@ Select.inherit_cache = True
 
 
 def get_sample(session: Session, sample_id: str) -> Sample:
-    """Get sample or raise 404"""
+    """Get sample or raise 404."""
 
     statement = select(Sample).where(Sample.id == sample_id)
     return session.exec(statement).one()
@@ -45,24 +45,24 @@ def get_incomplete_samples(statement: SelectOfScalar) -> SelectOfScalar:
 
 
 def get_plate_samples(statement: SelectOfScalar, plate_id: str) -> SelectOfScalar:
-    """Returning sample query statement for samples analysed on a specific plate"""
+    """Returning sample query statement for samples analysed on a specific plate."""
     return statement.where(Analysis.plate_id == plate_id)
 
 
 def get_commented_samples(statement: SelectOfScalar) -> SelectOfScalar:
-    """Returning sample query statement for samples with no comment"""
+    """Returning sample query statement for samples with no comment."""
 
     return statement.where(Sample.comment != None)
 
 
 def get_status_missing_samples(statement: SelectOfScalar) -> SelectOfScalar:
-    """Returning sample query statement for samples with no comment"""
+    """Returning sample query statement for samples with no comment."""
 
     return statement.where(Sample.status == None)
 
 
 def create_analyses_sample_objects(session: Session, analyses: List[Analysis]) -> List[Sample]:
-    """creating samples in an analysis if not already in db"""
+    """creating samples in an analysis if not already in db."""
     return [
         create_sample(session=session, sample=Sample(id=analysis_obj.sample_id))
         for analysis_obj in analyses


### PR DESCRIPTION
### Description
Currently when using both the plate_id and incomplete parameters, the following error is raised:

> sqlalchemy.exc.OperationalError: (pymysql.err.OperationalError) (1066, "Not unique table/alias: 'analysis'")
> [SQL: SELECT sample.status, sample.comment, sample.sex, sample.created_at, sample.id
> FROM sample INNER JOIN analysis ON sample.id = analysis.sample_id INNER JOIN analysis ON sample.id = analysis.sample_id
> WHERE analysis.plate_id = %(plate_id_1)s GROUP BY analysis.sample_id
> HAVING count(analysis.sample_id) < %(count_1)s ORDER BY analysis.created_at, sample.created_at DESC
>  LIMIT %(param_1)s, %(param_2)s]
> [parameters: {'plate_id_1': '120', 'count_1': 2, 'param_1': 0, 'param_2': 10}]

### Changed
- Moved the join(Analysis) statement out of the smaller functions

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


