### PR TITLE
fix(samples endpoint) Remove duplication

### DIFF
--- a/genotype_api/api/endpoints/samples.py
+++ b/genotype_api/api/endpoints/samples.py
@@ -96,7 +96,7 @@ def read_samples(
     current_user: User = Depends(get_active_user),
 ) -> List[Sample]:
     """Returns a list of samples matching the provided filters."""
-    statement: SelectOfScalar = select(Sample).join(Analysis)
+    statement: SelectOfScalar = select(Sample).distinct().join(Analysis)
     if sample_id:
         statement: SelectOfScalar = get_samples(statement=statement, sample_id=sample_id)
     if plate_id:


### PR DESCRIPTION
## Description
Since a completed sample has two analyses it shows up twice when searched for in the /samples endpoint, which makes usage of the endpoint confusing.

### Changed
- Samples with two analyses no longer show up twice from the /samples endpoint

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


