### PR TITLE
Use bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 LABEL base_image="python:3.10-slim"
 LABEL about.home="https://github.com/Clinical-Genomics/genotype-api"


### PR DESCRIPTION
The latest version of the python-3.10-slim image is broken, switching to bullseye.

### Fixed
- Change base image in Dockerfile to bullseye-slim

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
