### PR TITLE
bug(remove connection close on shutdown)

### DIFF
--- a/genotype_api/api/app.py
+++ b/genotype_api/api/app.py
@@ -76,8 +76,3 @@ app.include_router(
 def on_startup():
     initialise_database(settings.db_uri)
     create_all_tables()
-
-
-@app.on_event("shutdown")
-async def on_shutdown():
-    close_session()


### PR DESCRIPTION
### Added

I think this breaks genotype-api overnight. Had to restart it twice not due to SQL connection being not found. I introduced this prior. Not sure if this is the exact cause though.

### Changed

### Fixed


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


