### PR TITLE
Ensure session is closed

### DIFF
--- a/genotype_api/api/app.py
+++ b/genotype_api/api/app.py
@@ -20,12 +20,12 @@ app = FastAPI(
 )
 app.add_middleware(
     CORSMiddleware,
-    DBSessionMiddleware,
     allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(DBSessionMiddleware)
 
 
 @app.exception_handler(NoResultFound)

--- a/genotype_api/api/app.py
+++ b/genotype_api/api/app.py
@@ -7,8 +7,9 @@ from fastapi import FastAPI, status, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 
+from genotype_api.api.middleware import DBSessionMiddleware
 from genotype_api.config import security_settings, settings
-from genotype_api.database.database import create_all_tables, initialise_database, close_session
+from genotype_api.database.database import create_all_tables, initialise_database
 from genotype_api.api.endpoints import samples, snps, users, plates, analyses
 from sqlalchemy.exc import NoResultFound
 
@@ -19,6 +20,7 @@ app = FastAPI(
 )
 app.add_middleware(
     CORSMiddleware,
+    DBSessionMiddleware,
     allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],

--- a/genotype_api/api/middleware.py
+++ b/genotype_api/api/middleware.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+from genotype_api.database.database import close_session
+
+
+class DBSessionMiddleware:
+    async def __call__(self, request: Request, call_next):
+        try:
+            response = await call_next(request)
+        finally:
+            close_session()
+        return response

--- a/genotype_api/api/middleware.py
+++ b/genotype_api/api/middleware.py
@@ -1,11 +1,13 @@
 from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 from genotype_api.database.database import close_session
 
 
-class DBSessionMiddleware:
-    async def __call__(self, request: Request, call_next):
-        try:
-            response = await call_next(request)
-        finally:
-            close_session()
+class DBSessionMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app):
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        close_session()
         return response


### PR DESCRIPTION
Add a middleware ensuring the session is closed once the request has been processed to avoid timeout errors.

### Fixed
- Close session when request has been processed

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


