### PR TITLE
Patch(database) Add rollback un-commited transactions after requests

### DIFF
--- a/genotype_api/api/middleware.py
+++ b/genotype_api/api/middleware.py
@@ -5,6 +5,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from genotype_api.database.database import close_session, rollback_transactions
 
 LOG = logging.getLogger(__name__)
+
+
 class DBSessionMiddleware(BaseHTTPMiddleware):
     def __init__(self, app):
         super().__init__(app)

--- a/genotype_api/api/middleware.py
+++ b/genotype_api/api/middleware.py
@@ -13,12 +13,7 @@ class DBSessionMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         try:
-            LOG.error("Opening dispatching request")
             response = await call_next(request)
-        except Exception as error:
-            LOG.error(f"Caught exception: {error}")
-            rollback_transactions()
-            raise error
         finally:
             close_session()
         return response

--- a/genotype_api/api/middleware.py
+++ b/genotype_api/api/middleware.py
@@ -13,7 +13,7 @@ class DBSessionMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         try:
-            LOG.info("Opening dispathing request")
+            LOG.error("Opening dispatching request")
             response = await call_next(request)
         except Exception as error:
             LOG.error(f"Caught exception: {error}")

--- a/genotype_api/api/middleware.py
+++ b/genotype_api/api/middleware.py
@@ -1,10 +1,6 @@
-import logging
-
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
-from genotype_api.database.database import close_session, rollback_transactions
-
-LOG = logging.getLogger(__name__)
+from genotype_api.database.database import close_session
 
 
 class DBSessionMiddleware(BaseHTTPMiddleware):

--- a/genotype_api/api/middleware.py
+++ b/genotype_api/api/middleware.py
@@ -1,16 +1,20 @@
+import logging
+
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from genotype_api.database.database import close_session, rollback_transactions
 
-
+LOG = logging.getLogger(__name__)
 class DBSessionMiddleware(BaseHTTPMiddleware):
     def __init__(self, app):
         super().__init__(app)
 
     async def dispatch(self, request: Request, call_next):
         try:
+            LOG.info("Opening dispathing request")
             response = await call_next(request)
         except Exception as error:
+            LOG.error(f"Caught exception: {error}")
             rollback_transactions()
             raise error
         finally:

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -67,7 +67,7 @@ def get_tables() -> list[str]:
 def close_session():
     """Close the global database session of the genotype api."""
     LOG.error("Closing database session")
-    SESSION.close()
+    SESSION.remove()
 
 
 def rollback_transactions():

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -1,4 +1,5 @@
 """Hold the database information"""
+import logging
 
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.engine.base import Engine
@@ -10,6 +11,8 @@ from genotype_api.database.models import Base
 
 SESSION: scoped_session | None = None
 ENGINE: Engine | None = None
+
+LOG = logging.getLogger(__name__)
 
 
 def initialise_database(db_uri: str) -> None:
@@ -63,9 +66,11 @@ def get_tables() -> list[str]:
 
 def close_session():
     """Close the global database session of the genotype api."""
+    LOG.info("Closing database session")
     SESSION.close()
 
 
 def rollback_transactions():
     """Rollback the global database session of the genotype api."""
+    LOG.info("Rolling back database transactions")
     SESSION.rollback()

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -67,4 +67,3 @@ def get_tables() -> list[str]:
 def close_session():
     """Close the global database session of the genotype api."""
     SESSION.remove()
-

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -20,7 +20,7 @@ def initialise_database(db_uri: str) -> None:
     global SESSION, ENGINE
 
     ENGINE = create_engine(db_uri, pool_pre_ping=True)
-    session_factory = sessionmaker(ENGINE)
+    session_factory = sessionmaker(autoflush=False, bind=ENGINE)
     SESSION = scoped_session(session_factory)
 
 

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -66,11 +66,5 @@ def get_tables() -> list[str]:
 
 def close_session():
     """Close the global database session of the genotype api."""
-    LOG.error("Closing database session")
     SESSION.remove()
 
-
-def rollback_transactions():
-    """Rollback the global database session of the genotype api."""
-    LOG.error("Rolling back database transactions")
-    SESSION.rollback()

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -66,11 +66,11 @@ def get_tables() -> list[str]:
 
 def close_session():
     """Close the global database session of the genotype api."""
-    LOG.info("Closing database session")
+    LOG.error("Closing database session")
     SESSION.close()
 
 
 def rollback_transactions():
     """Rollback the global database session of the genotype api."""
-    LOG.info("Rolling back database transactions")
+    LOG.error("Rolling back database transactions")
     SESSION.rollback()

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -11,7 +11,6 @@ from genotype_api.database.models import Base
 
 SESSION: scoped_session | None = None
 ENGINE: Engine | None = None
-
 LOG = logging.getLogger(__name__)
 
 

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -1,7 +1,5 @@
 """Hold the database information"""
 
-import logging
-
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.engine.reflection import Inspector
@@ -12,7 +10,6 @@ from genotype_api.database.models import Base
 
 SESSION: scoped_session | None = None
 ENGINE: Engine | None = None
-LOG = logging.getLogger(__name__)
 
 
 def initialise_database(db_uri: str) -> None:

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -1,4 +1,5 @@
 """Hold the database information"""
+
 import logging
 
 from sqlalchemy import create_engine, inspect

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -64,3 +64,8 @@ def get_tables() -> list[str]:
 def close_session():
     """Close the global database session of the genotype api."""
     SESSION.close()
+
+
+def rollback_transactions():
+    """Rollback the global database session of the genotype api."""
+    SESSION.rollback()

--- a/genotype_api/database/database.py
+++ b/genotype_api/database/database.py
@@ -20,7 +20,7 @@ def initialise_database(db_uri: str) -> None:
     global SESSION, ENGINE
 
     ENGINE = create_engine(db_uri, pool_pre_ping=True)
-    session_factory = sessionmaker(autoflush=False, bind=ENGINE)
+    session_factory = sessionmaker(ENGINE)
     SESSION = scoped_session(session_factory)
 
 


### PR DESCRIPTION
### Description
Users have reported sporadic problems when using the application. The logs give the following error:

`sqlalchemy.exc.PendingRollbackError: Can't reconnect until invalid transaction is rolled back.  Please rollback() fully before proceeding (Background on this error at: https://sqlalche.me/e/20/8s2b)`

Having read up a bit in [the docs](https://docs.sqlalchemy.org/en/20/orm/contextual.html#contextual-thread-local-sessions) i found that using `.close()` on a scoped session does not rollback any transactions it has opened. For our purposes `.remove()` is what we need since it starts with closing the session but also rolls back any transactions it has open.


### Changed
- use SESSION.remove() instead of SESSION.close() after each request