### PR TITLE
Add genotype analysis loading

### DIFF
--- a/genotype_api/database/crud/read.py
+++ b/genotype_api/database/crud/read.py
@@ -247,7 +247,11 @@ class ReadHandler(BaseHandler):
         return (
             select(Sample)
             .distinct()
-            .options(selectinload(Sample.analyses).selectinload(Analysis.genotypes))
+            .options(
+                selectinload(Sample.analyses)
+                .selectinload(Analysis.genotypes)
+                .selectinload(Genotype.analysis)
+            )
             .join(Analysis, Analysis.sample_id == Sample.id)
         )
 

--- a/genotype_api/database/crud/read.py
+++ b/genotype_api/database/crud/read.py
@@ -247,11 +247,7 @@ class ReadHandler(BaseHandler):
         return (
             select(Sample)
             .distinct()
-            .options(
-                selectinload(Sample.analyses)
-                .selectinload(Analysis.genotypes)
-                .selectinload(Genotype.analysis)
-            )
+            .options(selectinload(Sample.analyses).selectinload(Analysis.genotypes))
             .join(Analysis, Analysis.sample_id == Sample.id)
         )
 

--- a/genotype_api/database/crud/update.py
+++ b/genotype_api/database/crud/update.py
@@ -32,7 +32,9 @@ class UpdateHandler(BaseHandler):
 
     async def update_sample_comment(self, sample_id: str, comment: str) -> Sample:
         query: Query = (
-            select(Sample).options(selectinload(Sample.analyses)).filter(Sample.id == sample_id)
+            select(Sample)
+            .options(selectinload(Sample.analyses).selectinload(Analysis.genotypes))
+            .filter(Sample.id == sample_id)
         )
         sample: Sample = await self.fetch_one_or_none(query)
 

--- a/genotype_api/database/crud/update.py
+++ b/genotype_api/database/crud/update.py
@@ -31,10 +31,14 @@ class UpdateHandler(BaseHandler):
         return sample
 
     async def update_sample_comment(self, sample_id: str, comment: str) -> Sample:
-        query: Query = select(Sample).distinct().filter(Sample.id == sample_id)
+        query: Query = (
+            select(Sample).options(selectinload(Sample.analyses)).filter(Sample.id == sample_id)
+        )
         sample: Sample = await self.fetch_one_or_none(query)
+
         if not sample:
             raise SampleNotFoundError
+
         sample.comment = comment
         self.session.add(sample)
         await self.session.commit()


### PR DESCRIPTION
# Reported Bug
An issue was reported related to `update_comment`, and the logs show:
```
File "/home/worker/app/genotype_api/api/endpoints/samples.py", line 143, in update_comment
    return await sample_service.set_sample_comment(sample_id=sample_id, comment=comment)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/genotype_api/services/endpoint_services/sample_service.py", line 137, in set_sample_comment
    return self._get_sample_response(sample)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/genotype_api/services/endpoint_services/sample_service.py", line 57, in _get_sample_response
    analyses: list[AnalysisOnSample] = self._get_analyses_on_sample(sample=sample)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/genotype_api/services/endpoint_services/sample_service.py", line 41, in _get_analyses_on_sample
    if not sample.analyses:
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 566, in __get__
    return self.impl.get(state, dict_)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 1086, in get
    value = self._fire_loader_callables(state, key, passive)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 1121, in _fire_loader_callables
    return self.callable_(state, passive)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/strategies.py", line 967, in _load_for_state
    return self._emit_lazyload(
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/strategies.py", line 1130, in _emit_lazyload
    result = session.execute(
             ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2362, in execute
    return self._execute_internal(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2247, in _execute_internal
    result: Result[Any] = compile_state_cls.orm_execute_statement(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/orm/context.py", line 305, in orm_execute_statement
    result = conn.execute(
             ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1418, in execute
    return meth(
           ^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/sql/elements.py", line 515, in _execute_on_connection
    return connection._execute_clauseelement(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1640, in _execute_clauseelement
    ret = self._execute_context(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1821, in _execute_context
    self._handle_dbapi_exception(
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 2355, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1815, in _execute_context
    context = constructor(
              ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 1418, in _init_compiled
    self.cursor = self.create_cursor()
                  ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 1752, in create_cursor
    return self.create_default_cursor()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 1758, in create_default_cursor
    return self._dbapi_connection.cursor()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/pool/base.py", line 1485, in cursor
    return self.dbapi_connection.cursor(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/dialects/mysql/aiomysql.py", line 198, in cursor
    return AsyncAdapt_aiomysql_cursor(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/dialects/mysql/aiomysql.py", line 61, in __init__
    self._cursor = self.await_(cursor.__aenter__())
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 123, in await_only
    raise exc.MissingGreenlet(
sqlalchemy.exc.StatementError: (sqlalchemy.exc.MissingGreenlet) greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place?
[SQL: SELECT analysis.id AS analysis_id, analysis.type AS analysis_type, analysis.source AS analysis_source, analysis.sex AS analysis_sex, analysis.created_at AS analysis_created_at, analysis.sample_id AS analysis_sample_id, analysis.plate_id AS analysis_plate_id
FROM analysis
WHERE %s = analysis.sample_id]
[parameters: [{'%(XXXXXXXXXXX param)s': 'XXXXXX'}]]
(Background on this error at: https://sqlalche.me/e/20/xd2s)
```